### PR TITLE
StoreImpl sync object suggestions

### DIFF
--- a/cotea/src/main/java/com/mw/cotea_core/store/StoreImpl.kt
+++ b/cotea/src/main/java/com/mw/cotea_core/store/StoreImpl.kt
@@ -24,7 +24,7 @@ internal class StoreImpl<Message, State, SideEffect, Command>(
     private val commandMessageSourceStarted = CompletableDeferred<Unit>()
 
     override suspend fun onMessage(message: Message) {
-        stateSourceStarted.await()
+        stateSourceStarted.join()
         stateMachine.onMessage(message)
     }
 
@@ -73,11 +73,11 @@ internal class StoreImpl<Message, State, SideEffect, Command>(
             .launchIn(coroutineScope)
 
         coroutineScope.launch {
-            transitionSourceStarted.await()
-            sideEffectSourceStarted.await()
-            commandMessageSourceStarted.await()
-            commandSourceStarted.await()
-            stateSourceStarted.await()
+            transitionSourceStarted.join()
+            sideEffectSourceStarted.join()
+            commandMessageSourceStarted.join()
+            commandSourceStarted.join()
+            stateSourceStarted.join()
             stateMachine.emitInitialCommands(initialCommands)
         }
     }

--- a/cotea/src/test/kotlin/com/mw/cotea_core/state_machine/StateMachineTest.kt
+++ b/cotea/src/test/kotlin/com/mw/cotea_core/state_machine/StateMachineTest.kt
@@ -29,21 +29,16 @@ internal class StateMachineTest {
 
     private val stateUpdater: StateUpdater<Message, State, SideEffect, Command> = mockk(relaxed = true)
 
-    private val stateMachine: StateMachine<Message, State, SideEffect, Command>
-        get() = lazyStateMachine.value
-
-    private var lazyStateMachine by Delegates.notNull<Lazy<StateMachine<Message, State, SideEffect, Command>>>()
+    private lateinit var stateMachine: StateMachine<Message, State, SideEffect, Command>
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
-        lazyStateMachine = lazy {
-            StateMachine<Message, State, SideEffect, Command>(
-                stateUpdater = stateUpdater,
-                initialState = INITIAL_STATE,
-                dispatcherDefault = UnconfinedTestDispatcher()
-            )
-        }
+        stateMachine = StateMachine(
+            stateUpdater = stateUpdater,
+            initialState = INITIAL_STATE,
+            dispatcherDefault = UnconfinedTestDispatcher()
+        )
     }
 
     @Test
@@ -98,36 +93,49 @@ internal class StateMachineTest {
     }
 
     @Test
-    fun `when StateUpdater return updatedState equal previousState then StateMachine not emit updatedState`() = runTest {
-        every { stateUpdater.update(state = INITIAL_STATE, message = any()) } returns Update.state(INITIAL_STATE)
+    fun `when StateUpdater return updatedState equal previousState then StateMachine not emit updatedState`() =
+        runTest {
+            every { stateUpdater.update(state = INITIAL_STATE, message = any()) } returns Update.state(INITIAL_STATE)
 
-        turbineScope {
-            val stateSource = stateMachine.getStateSource().testIn(backgroundScope)
-            stateSource.skipItems(1) // skip INITIAL_STATE
-            stateMachine.onMessage(MESSAGE)
-            assertFails { stateSource.awaitItem() }
+            turbineScope {
+                val stateSource = stateMachine.getStateSource().testIn(backgroundScope)
+                stateSource.skipItems(1) // skip INITIAL_STATE
+                stateMachine.onMessage(MESSAGE)
+                assertFails { stateSource.awaitItem() }
+            }
         }
-    }
 
     @Test
     fun `when StateUpdater return Update then StateMachine emit Transition to transitionSource`() = runTest {
-        every { stateUpdater.update(state = INITIAL_STATE, message = MESSAGE) } returns Update.stateWithSideEffectsWithCommands(REDUCED_STATE, listOf(SIDE_EFFECT), listOf(COMMAND))
+        every {
+            stateUpdater.update(
+                state = INITIAL_STATE,
+                message = MESSAGE
+            )
+        } returns Update.stateWithSideEffectsWithCommands(REDUCED_STATE, listOf(SIDE_EFFECT), listOf(COMMAND))
         turbineScope {
             val transitionSource = stateMachine.getTransitionSource().testIn(backgroundScope)
             stateMachine.getStateSource().testIn(backgroundScope)
             stateMachine.onMessage(MESSAGE)
-            assertEquals(Transition(INITIAL_STATE, MESSAGE, REDUCED_STATE, listOf(SIDE_EFFECT), listOf(COMMAND)), transitionSource.awaitItem())
+            assertEquals(
+                Transition(INITIAL_STATE, MESSAGE, REDUCED_STATE, listOf(SIDE_EFFECT), listOf(COMMAND)),
+                transitionSource.awaitItem()
+            )
         }
     }
 
     @Test
-    fun `when StateUpdater return updatedState equal previousState then StateMachine emit Transition to transitionSource`() = runTest {
-        every { stateUpdater.update(state = INITIAL_STATE, message = MESSAGE) } returns Update.state(INITIAL_STATE)
-        turbineScope {
-            val transitionSource = stateMachine.getTransitionSource().testIn(backgroundScope)
-            stateMachine.getStateSource().testIn(backgroundScope)
-            stateMachine.onMessage(MESSAGE)
-            assertEquals(Transition(INITIAL_STATE, MESSAGE, INITIAL_STATE, listOf<SideEffect>(), listOf<Command>()), transitionSource.awaitItem())
+    fun `when StateUpdater return updatedState equal previousState then StateMachine emit Transition to transitionSource`() =
+        runTest {
+            every { stateUpdater.update(state = INITIAL_STATE, message = MESSAGE) } returns Update.state(INITIAL_STATE)
+            turbineScope {
+                val transitionSource = stateMachine.getTransitionSource().testIn(backgroundScope)
+                stateMachine.getStateSource().testIn(backgroundScope)
+                stateMachine.onMessage(MESSAGE)
+                assertEquals(
+                    Transition(INITIAL_STATE, MESSAGE, INITIAL_STATE, listOf<SideEffect>(), listOf<Command>()),
+                    transitionSource.awaitItem()
+                )
+            }
         }
-    }
 }


### PR DESCRIPTION
Предложение вместо `join` использовать `await`, результат будет одинаковый, но на мой взгляд инструкция `await` точнее  показывает, что требуется дождаться инициализации объектов.
В новом тесте `StoreImpl` проверяется, что инструкция `emitInitialCommands` будет вызвана после инициализации всех объектов, т.е. синхронизация выполнена корректно. Ленивая инициализация для простоты заменена на `lateinit` 