### PR TITLE
Configure publishing

### DIFF
--- a/cotea/build.gradle.kts
+++ b/cotea/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
     id("java-library")
@@ -5,8 +7,12 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 }
 
 dependencies {
@@ -24,8 +30,6 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "com.github.MikhailZhalskiy"
             artifactId = "cotea"
-            version = "0.1"
-
             from(components["kotlin"])
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+version=0.1


### PR DESCRIPTION
Сборка библиотеки под JVM 11, чтобы можно было подключить к проектам, которые еще не перешли на новую версию AGP