### PR TITLE
configure deploy lib

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+sed -ir "s/^[#]*\s*version=.*/version=$1/" gradle.properties
+git add . && git commit -m "Release version $1" &&
+git tag $1 &&
+git push origin && git push origin --tags

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+version=0.1


### PR DESCRIPTION
Конфигурация для публикации новой версии библиотеки в `jitpack.io`
Чтобы выпустить новую версию нужно запустить: `./deploy.sh 0.1`, где 0.1 - номер версии
После этого нужно зайти на `jitpack.io` и запустить сборку